### PR TITLE
Fix InvalidOperationException caused by sync Write()

### DIFF
--- a/USG.Authorization.AspNetCore/WhitelistMiddleware.cs
+++ b/USG.Authorization.AspNetCore/WhitelistMiddleware.cs
@@ -29,7 +29,7 @@ namespace USG.Authorization
                         $"Host {ip} is not whitelisted for this site.");
 
                     context.Response.StatusCode = 403;
-                    context.Response.Body.Write(message);
+                    await context.Response.Body.WriteAsync(message);
                 }
             });
         }


### PR DESCRIPTION
Kestrel now throws an InvalidOperationException:

> Synchronous operations are disallowed. Call WriteAsync or set
> AllowSynchronousIO to true instead.

...so use WriteAsync() instead.